### PR TITLE
Fix props mismatch between QRGenerator and DownloadOptions

### DIFF
--- a/src/components/DownloadOptions.jsx
+++ b/src/components/DownloadOptions.jsx
@@ -1,10 +1,8 @@
 import { Button, Stack, FormControlLabel, Checkbox } from "@mui/material";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
-import { useState } from "react";
 
-const DownloadOptions = ({ text, bgColor }) => {
-  const [transparent, setTransparent] = useState(bgColor === "transparent");
+const DownloadOptions = ({ text, bgColor, transparent, setTransparent }) => {
 
   const downloadQRAsImage = () => {
     const qrElement = document.getElementById("qr-code");

--- a/src/components/QRGenerator.jsx
+++ b/src/components/QRGenerator.jsx
@@ -42,8 +42,13 @@ const QRGenerator = () => {
 
         <Box sx={{ width: "100%", display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
           <QRCustomization text={text} setText={setText} color={color} setColor={setColor} bgColor={bgColor} setBgColor={setBgColor} />
-          <QRCodeDisplay text={text} color={color} bgColor={bgColor} transparent={transparent} />
-          <DownloadOptions text={text} transparent={transparent} setTransparent={setTransparent} />
+          <QRCodeDisplay text={text} color={color} bgColor={bgColor} />
+          <DownloadOptions
+            text={text}
+            bgColor={bgColor}
+            transparent={transparent}
+            setTransparent={setTransparent}
+          />
         </Box>
       </Paper>
     </Box>


### PR DESCRIPTION
## Summary
- pass background color and transparency state correctly
- update DownloadOptions to accept props from parent
- remove unused transparent prop from QRCodeDisplay

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c55a4f3588325b30cb49efe09810f