### PR TITLE
Add WhatsApp link generator and QR history

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ A **QR Code Generator** with customization options for colors, background, and d
 
 ## **🚀 Features**
 
-✅ Real-time QR code generation.  
-✅ Customizable QR code colors and background.  
-✅ Option for a **transparent background**.  
-✅ Download as **PNG** (with or without background).  
-✅ Download as **PDF** (centered and optimized).  
-✅ **Responsive design** with **Material UI**.  
+✅ Real-time QR code generation.
+✅ Customizable QR code colors and background.
+✅ Option for a **transparent background**.
+✅ Download as **PNG** (with or without background).
+✅ Download as **PDF** (centered and optimized).
+✅ **Responsive design** with **Material UI**.
+✅ Generate **WhatsApp links** quickly.
+✅ Local history of recent QR codes (cleared on reload).
 ✅ **Runs with Docker and Docker Compose**.
 
 ---

--- a/src/components/QRGenerator.jsx
+++ b/src/components/QRGenerator.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import QRCustomization from "./QRCustomization";
+import WhatsAppLink from "./WhatsAppLink";
 import QRCodeDisplay from "./QRCodeDisplay";
+import QRHistory from "./QRHistory";
 import DownloadOptions from "./DownloadOptions";
-import { Typography, Paper, Box, useTheme } from "@mui/material";
+import { Typography, Paper, Box, Button, useTheme } from "@mui/material";
 
 const QRGenerator = () => {
   const theme = useTheme();
@@ -10,6 +12,12 @@ const QRGenerator = () => {
   const [color, setColor] = useState("#000000");
   const [bgColor, setBgColor] = useState("#ffffff");
   const [transparent, setTransparent] = useState(false);
+  const [history, setHistory] = useState([]);
+
+  const saveToHistory = () => {
+    const item = { text, color, bgColor };
+    setHistory((prev) => [item, ...prev].slice(0, 5));
+  };
 
   return (
     <Box
@@ -41,14 +49,25 @@ const QRGenerator = () => {
         </Typography>
 
         <Box sx={{ width: "100%", display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
-          <QRCustomization text={text} setText={setText} color={color} setColor={setColor} bgColor={bgColor} setBgColor={setBgColor} />
+          <QRCustomization
+            text={text}
+            setText={setText}
+            color={color}
+            setColor={setColor}
+            bgColor={bgColor}
+            setBgColor={setBgColor}
+          />
+          <WhatsAppLink setText={setText} />
           <QRCodeDisplay text={text} color={color} bgColor={bgColor} />
+          <Button variant="outlined" onClick={saveToHistory}
+            sx={{ mt: 1 }}>Save to History</Button>
           <DownloadOptions
             text={text}
             bgColor={bgColor}
             transparent={transparent}
             setTransparent={setTransparent}
           />
+          <QRHistory history={history} />
         </Box>
       </Paper>
     </Box>

--- a/src/components/QRHistory.jsx
+++ b/src/components/QRHistory.jsx
@@ -1,0 +1,23 @@
+import { Box, Typography, Stack } from "@mui/material";
+import { QRCodeSVG } from "qrcode.react";
+
+const QRHistory = ({ history }) => {
+  if (!history.length) return null;
+
+  return (
+    <Box sx={{ width: "100%", textAlign: "center" }}>
+      <Typography variant="h6" color="text.primary" gutterBottom>
+        Recent QR Codes
+      </Typography>
+      <Stack direction="row" spacing={2} sx={{ flexWrap: "wrap", justifyContent: "center" }}>
+        {history.map((item, index) => (
+          <Box key={index} sx={{ p: 1, bgcolor: item.bgColor, borderRadius: 1 }}>
+            <QRCodeSVG value={item.text} size={80} fgColor={item.color} bgColor="transparent" />
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export default QRHistory;

--- a/src/components/WhatsAppLink.jsx
+++ b/src/components/WhatsAppLink.jsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { TextField, Button, Box, Typography } from "@mui/material";
+
+const WhatsAppLink = ({ setText }) => {
+  const [phone, setPhone] = useState("");
+  const [message, setMessage] = useState("");
+
+  const generateLink = () => {
+    if (!phone) return;
+    const encodedMessage = encodeURIComponent(message);
+    const link = `https://wa.me/${phone}${message ? `?text=${encodedMessage}` : ""}`;
+    setText(link);
+  };
+
+  return (
+    <Box sx={{ width: "100%", textAlign: "center" }}>
+      <Typography variant="h6" color="text.primary" gutterBottom>
+        WhatsApp Link
+      </Typography>
+      <TextField
+        fullWidth
+        label="Phone Number"
+        variant="outlined"
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      <TextField
+        fullWidth
+        label="Message (optional)"
+        variant="outlined"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      <Button variant="contained" onClick={generateLink} disabled={!phone}>
+        Generate WhatsApp Link
+      </Button>
+    </Box>
+  );
+};
+
+export default WhatsAppLink;


### PR DESCRIPTION
## Summary
- allow generating WhatsApp links
- keep a temporary history of recent QR codes
- document new functionality

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c5d39d1088325bb0a82db2093334e