### PR TITLE
Improve input validation and warnings

### DIFF
--- a/src/components/DownloadOptions.jsx
+++ b/src/components/DownloadOptions.jsx
@@ -2,9 +2,18 @@ import { Button, Stack, FormControlLabel, Checkbox } from "@mui/material";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
 
-const DownloadOptions = ({ text, bgColor, transparent, setTransparent }) => {
+const DownloadOptions = ({ text, bgColor, transparent, setTransparent, onInvalid }) => {
+
+  const isEmpty = () => {
+    if (!text.trim()) {
+      onInvalid && onInvalid("Please enter text before downloading.");
+      return true;
+    }
+    return false;
+  };
 
   const downloadQRAsImage = () => {
+    if (isEmpty()) return;
     const qrElement = document.getElementById("qr-code");
 
     if (!qrElement) {
@@ -48,6 +57,7 @@ const DownloadOptions = ({ text, bgColor, transparent, setTransparent }) => {
   };
 
   const downloadQRAsPDF = () => {
+    if (isEmpty()) return;
     const qrElement = document.getElementById("qr-code");
 
     if (!qrElement) {

--- a/src/components/QRCustomization.jsx
+++ b/src/components/QRCustomization.jsx
@@ -1,6 +1,18 @@
 import { TextField, Box, Typography, Stack } from "@mui/material";
 
-const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor }) => {
+const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, error, setError }) => {
+
+  const handleChange = (e) => {
+    const value = e.target.value;
+    const asciiRegex = /^[\x00-\x7F]*$/;
+    if (!asciiRegex.test(value)) {
+      setError("Invalid characters detected");
+    } else {
+      setError("");
+    }
+    setText(value);
+  };
+
   return (
     <Box sx={{ width: "100%", textAlign: "center" }}>
       <Typography variant="h6" color="text.primary" gutterBottom>
@@ -9,10 +21,14 @@ const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor }
 
       <TextField
         fullWidth
-        label="Enter text"
+        label="QR Text"
+        placeholder="Enter text or URL to encode"
         variant="outlined"
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        onChange={handleChange}
+        inputProps={{ maxLength: 300 }}
+        error={Boolean(error)}
+        helperText={error || `${text.length} / 300`}
         sx={{ mb: 2 }}
       />
 

--- a/src/components/QRGenerator.jsx
+++ b/src/components/QRGenerator.jsx
@@ -2,7 +2,14 @@ import { useState } from "react";
 import QRCustomization from "./QRCustomization";
 import QRCodeDisplay from "./QRCodeDisplay";
 import DownloadOptions from "./DownloadOptions";
-import { Typography, Paper, Box, useTheme } from "@mui/material";
+import {
+  Typography,
+  Paper,
+  Box,
+  useTheme,
+  Snackbar,
+  Alert,
+} from "@mui/material";
 
 const QRGenerator = () => {
   const theme = useTheme();
@@ -10,6 +17,8 @@ const QRGenerator = () => {
   const [color, setColor] = useState("#000000");
   const [bgColor, setBgColor] = useState("#ffffff");
   const [transparent, setTransparent] = useState(false);
+  const [error, setError] = useState("");
+  const [warning, setWarning] = useState("");
 
   return (
     <Box
@@ -41,15 +50,33 @@ const QRGenerator = () => {
         </Typography>
 
         <Box sx={{ width: "100%", display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
-          <QRCustomization text={text} setText={setText} color={color} setColor={setColor} bgColor={bgColor} setBgColor={setBgColor} />
+          <QRCustomization
+            text={text}
+            setText={setText}
+            color={color}
+            setColor={setColor}
+            bgColor={bgColor}
+            setBgColor={setBgColor}
+            error={error}
+            setError={setError}
+          />
           <QRCodeDisplay text={text} color={color} bgColor={bgColor} />
           <DownloadOptions
             text={text}
             bgColor={bgColor}
             transparent={transparent}
             setTransparent={setTransparent}
+            onInvalid={setWarning}
           />
         </Box>
+        <Snackbar
+          open={Boolean(warning)}
+          autoHideDuration={3000}
+          onClose={() => setWarning("")}
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        >
+          <Alert severity="warning" variant="filled" onClose={() => setWarning("")}> {warning} </Alert>
+        </Snackbar>
       </Paper>
     </Box>
   );


### PR DESCRIPTION
## Summary
- validate input text and show char counter
- prevent downloads when the text field is empty
- show snackbar warning when trying to download without text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c5fcecbb88325bae825fc00eae853