### PR TITLE
Add color picker with hex input and reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A **QR Code Generator** with customization options for colors, background, and d
 ## **🚀 Features**
 
 ✅ Real-time QR code generation.  
-✅ Customizable QR code colors and background.  
+✅ Customizable QR code colors and background with hex preview and reset option.
 ✅ Option for a **transparent background**.  
 ✅ Download as **PNG** (with or without background).  
 ✅ Download as **PDF** (centered and optimized).  

--- a/src/components/ColorPicker.jsx
+++ b/src/components/ColorPicker.jsx
@@ -1,0 +1,45 @@
+import { Box, Typography, TextField } from "@mui/material";
+
+const ColorPicker = ({ label, color, setColor }) => {
+  const handleHexChange = (e) => {
+    let value = e.target.value;
+    if (!value.startsWith("#")) {
+      value = `#${value}`;
+    }
+    // Limit to 7 characters (# + 6 hex digits)
+    if (value.length > 7) {
+      value = value.slice(0, 7);
+    }
+    setColor(value);
+  };
+
+  return (
+    <Box sx={{ textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <input
+        type="color"
+        value={color}
+        onChange={(e) => setColor(e.target.value)}
+        style={{
+          width: "40px",
+          height: "40px",
+          borderRadius: "50%",
+          border: "1px solid #ccc",
+          cursor: "pointer",
+          marginBottom: "4px",
+        }}
+      />
+      <TextField
+        value={color}
+        onChange={handleHexChange}
+        variant="outlined"
+        size="small"
+        inputProps={{ maxLength: 7 }}
+      />
+    </Box>
+  );
+};
+
+export default ColorPicker;

--- a/src/components/QRCustomization.jsx
+++ b/src/components/QRCustomization.jsx
@@ -1,4 +1,5 @@
-import { TextField, Box, Typography, Stack } from "@mui/material";
+import { TextField, Box, Typography, Stack, Button } from "@mui/material";
+import ColorPicker from "./ColorPicker";
 
 const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, error, setError }) => {
 
@@ -32,43 +33,20 @@ const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, 
         sx={{ mb: 2 }}
       />
 
-      <Stack direction="row" justifyContent="space-between" alignItems="center">
-        <Box sx={{ textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center" }}>
-          <Typography variant="body2" color="text.secondary">
-            Color
-          </Typography>
-          <input
-            type="color"
-            value={color}
-            onChange={(e) => setColor(e.target.value)}
-            style={{
-              width: "40px",
-              height: "40px",
-              borderRadius: "50%",
-              border: "1px solid #ccc",
-              cursor: "pointer",
-            }}
-          />
-        </Box>
-
-        <Box sx={{ textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center" }}>
-          <Typography variant="body2" color="text.secondary">
-            Background
-          </Typography>
-          <input
-            type="color"
-            value={bgColor}
-            onChange={(e) => setBgColor(e.target.value)}
-            style={{
-              width: "40px",
-              height: "40px",
-              borderRadius: "50%",
-              border: "1px solid #ccc",
-              cursor: "pointer",
-            }}
-          />
-        </Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2} sx={{ mb: 2 }}>
+        <ColorPicker label="Color" color={color} setColor={setColor} />
+        <ColorPicker label="Background" color={bgColor} setColor={setBgColor} />
       </Stack>
+
+      <Button
+        variant="outlined"
+        onClick={() => {
+          setColor("#000000");
+          setBgColor("#ffffff");
+        }}
+      >
+        Reset Colors
+      </Button>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- implement reusable `ColorPicker` component
- display hex value editable via text field
- add Reset Colors button in customization section
- document new customization features

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c616dd40883258032a27d848dc631