### PR TITLE
Add reset colors feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ A **QR Code Generator** with customization options for colors, background, and d
 ## **🚀 Features**
 
 ✅ Real-time QR code generation.  
-✅ Customizable QR code colors and background.  
-✅ Option for a **transparent background**.  
+✅ Customizable QR code colors and background.
+✅ Reset colors to default with one click.
+✅ Option for a **transparent background**.
 ✅ Download as **PNG** (with or without background).  
 ✅ Download as **PDF** (centered and optimized).  
 ✅ **Responsive design** with **Material UI**.  

--- a/src/components/QRCustomization.jsx
+++ b/src/components/QRCustomization.jsx
@@ -1,4 +1,4 @@
-import { TextField, Box, Typography, Stack } from "@mui/material";
+import { TextField, Box, Typography, Stack, Button } from "@mui/material";
 
 const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, error, setError }) => {
 
@@ -11,6 +11,11 @@ const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, 
       setError("");
     }
     setText(value);
+  };
+
+  const handleResetColors = () => {
+    setColor("#000000");
+    setBgColor("#ffffff");
   };
 
   return (
@@ -69,6 +74,9 @@ const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, 
           />
         </Box>
       </Stack>
+      <Button variant="outlined" onClick={handleResetColors} sx={{ mt: 2 }}>
+        Reset Colors
+      </Button>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- allow users to reset QR color settings back to defaults
- document new reset option in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c64139ff083259986b197235e6582