### PR TITLE
Add QR shape customization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mui/material": "^6.4.4",
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.2",
-        "qrcode.react": "^4.2.0",
+        "qr-code-styling": "^1.5.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -4004,6 +4004,12 @@
         "html2canvas": "^1.0.0-rc.5"
       }
     },
+    "node_modules/qr-code-styling": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/qr-code-styling/-/qr-code-styling-1.5.0.tgz",
+      "integrity": "",
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -4494,15 +4500,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qrcode.react": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
-      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/raf": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/material": "^6.4.4",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.2",
-    "qrcode.react": "^4.2.0",
+    "qr-code-styling": "^1.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/components/QRCodeDisplay.jsx
+++ b/src/components/QRCodeDisplay.jsx
@@ -1,7 +1,26 @@
-import { QRCodeSVG } from "qrcode.react";
+import { useEffect, useRef } from "react";
 import { Box } from "@mui/material";
+import QRCodeStyling from "qr-code-styling";
 
-const QRCodeDisplay = ({ text, color, bgColor, logo }) => {
+const QRCodeDisplay = ({ text, color, bgColor, shape, logo }) => {
+  const ref = useRef(null);
+  const qrRef = useRef(null);
+
+  useEffect(() => {
+    if (!qrRef.current) {
+      qrRef.current = new QRCodeStyling({
+        width: 220,
+        height: 220,
+        data: text,
+        dotsOptions: { color, type: shape },
+        backgroundOptions: { color: "transparent" },
+      });
+      qrRef.current.append(ref.current);
+    } else {
+      qrRef.current.update({ data: text, dotsOptions: { color, type: shape } });
+    }
+  }, [text, color, shape]);
+
   return (
     <Box
       id="qr-code"
@@ -10,15 +29,15 @@ const QRCodeDisplay = ({ text, color, bgColor, logo }) => {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        width: 250,
-        height: 250,
+        width: 220,
+        height: 220,
         bgcolor: bgColor,
         padding: 2,
         borderRadius: bgColor !== "transparent" ? "16px" : "0px",
         boxShadow: bgColor !== "transparent" ? 3 : 0,
       }}
     >
-      <QRCodeSVG value={text} size={220} fgColor={color} bgColor="transparent" />
+      <Box ref={ref} />
       {logo && (
         <img
           src={logo}

--- a/src/components/QRCustomization.jsx
+++ b/src/components/QRCustomization.jsx
@@ -1,6 +1,7 @@
 import { TextField, Box, Typography, Stack } from "@mui/material";
+import QRShapeSelector from "./QRShapeSelector";
 
-const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, error, setError }) => {
+const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, shape, setShape, error, setError }) => {
 
   const handleChange = (e) => {
     const value = e.target.value;
@@ -69,6 +70,7 @@ const QRCustomization = ({ text, setText, color, setColor, bgColor, setBgColor, 
           />
         </Box>
       </Stack>
+      <QRShapeSelector shape={shape} setShape={setShape} color={color} />
     </Box>
   );
 };

--- a/src/components/QRGenerator.jsx
+++ b/src/components/QRGenerator.jsx
@@ -16,6 +16,7 @@ const QRGenerator = () => {
   const [text, setText] = useState("Hello World");
   const [color, setColor] = useState("#000000");
   const [bgColor, setBgColor] = useState("#ffffff");
+  const [shape, setShape] = useState("square");
   const [transparent, setTransparent] = useState(false);
   const [error, setError] = useState("");
   const [warning, setWarning] = useState("");
@@ -37,7 +38,7 @@ const QRGenerator = () => {
         sx={{
           p: 4,
           width: "100%",
-          maxWidth: 500,
+          maxWidth: 420,
           textAlign: "center",
           display: "flex",
           flexDirection: "column",
@@ -57,10 +58,12 @@ const QRGenerator = () => {
             setColor={setColor}
             bgColor={bgColor}
             setBgColor={setBgColor}
+            shape={shape}
+            setShape={setShape}
             error={error}
             setError={setError}
           />
-          <QRCodeDisplay text={text} color={color} bgColor={bgColor} />
+          <QRCodeDisplay text={text} color={color} bgColor={bgColor} shape={shape} />
           <DownloadOptions
             text={text}
             bgColor={bgColor}

--- a/src/components/QRShapeSelector.jsx
+++ b/src/components/QRShapeSelector.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import { Box, Typography, RadioGroup, FormControlLabel, Radio } from "@mui/material";
+import QRCodeStyling from "qr-code-styling";
+
+const shapeOptions = [
+  { label: "Cuadrado", value: "square", type: "square" },
+  { label: "Puntos", value: "dots", type: "dots" },
+  { label: "Pixelado", value: "rounded", type: "rounded" },
+  { label: "Art\u00edstico", value: "classy", type: "classy" },
+];
+
+const QRShapeSelector = ({ shape, setShape, color }) => {
+  const refs = useRef([]);
+
+  useEffect(() => {
+    shapeOptions.forEach((opt, idx) => {
+      const container = refs.current[idx];
+      if (!container) return;
+      const qr = new QRCodeStyling({
+        width: 60,
+        height: 60,
+        data: "demo",
+        dotsOptions: {
+          color,
+          type: opt.type,
+        },
+        backgroundOptions: { color: "transparent" },
+      });
+      container.innerHTML = "";
+      qr.append(container);
+    });
+  }, [color]);
+
+  return (
+    <Box sx={{ textAlign: "center", mt: 2 }}>
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        Forma
+      </Typography>
+      <RadioGroup
+        row
+        value={shape}
+        onChange={(e) => setShape(e.target.value)}
+        sx={{ justifyContent: "center" }}
+      >
+        {shapeOptions.map((opt, idx) => (
+          <FormControlLabel
+            key={opt.value}
+            value={opt.value}
+            control={<Radio />}
+            label={
+              <Box
+                sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+              >
+                <Box ref={(el) => (refs.current[idx] = el)} sx={{ width: 60, height: 60 }} />
+                <Typography variant="caption">{opt.label}</Typography>
+              </Box>
+            }
+          />
+        ))}
+      </RadioGroup>
+    </Box>
+  );
+};
+
+export default QRShapeSelector;


### PR DESCRIPTION
## Summary
- add `qr-code-styling` dependency for shape customisation
- remove old `qrcode.react` dependency
- implement `QRShapeSelector` with radio preview options
- update `QRCustomization` and generator to handle shape selection
- switch QR display to `qr-code-styling` and shrink layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6527a36c83259b95a3d9e98aea44