### PR TITLE
Improve QR export and logo controls

### DIFF
--- a/src/components/DownloadOptions.jsx
+++ b/src/components/DownloadOptions.jsx
@@ -25,9 +25,11 @@ const DownloadOptions = ({ text, bgColor, transparent, setTransparent, onInvalid
 
     const originalBg = qrElement.style.backgroundColor;
     const originalBorderRadius = qrElement.style.borderRadius;
+    const originalResize = qrElement.style.resize;
 
     qrElement.style.backgroundColor = transparent ? "transparent" : bgColor;
     qrElement.style.borderRadius = "0px";
+    qrElement.style.resize = "none";
 
     setTimeout(() => {
       html2canvas(qrElement, {
@@ -42,6 +44,7 @@ const DownloadOptions = ({ text, bgColor, transparent, setTransparent, onInvalid
 
         qrElement.style.backgroundColor = originalBg;
         qrElement.style.borderRadius = originalBorderRadius;
+        qrElement.style.resize = originalResize;
       });
     }, 300);
   };
@@ -57,9 +60,11 @@ const DownloadOptions = ({ text, bgColor, transparent, setTransparent, onInvalid
 
     const originalBg = qrElement.style.backgroundColor;
     const originalBorderRadius = qrElement.style.borderRadius;
+    const originalResize = qrElement.style.resize;
 
     qrElement.style.backgroundColor = transparent ? "transparent" : bgColor;
     qrElement.style.borderRadius = "0px";
+    qrElement.style.resize = "none";
 
     setTimeout(() => {
       html2canvas(qrElement, { scale: 4 }).then((canvas) => {
@@ -81,6 +86,7 @@ const DownloadOptions = ({ text, bgColor, transparent, setTransparent, onInvalid
 
         qrElement.style.backgroundColor = originalBg;
         qrElement.style.borderRadius = originalBorderRadius;
+        qrElement.style.resize = originalResize;
       });
     }, 300);
   };

--- a/src/components/LogoUploader.jsx
+++ b/src/components/LogoUploader.jsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { Box, Button, Stack, Avatar, IconButton } from "@mui/material";
 import CloseIcon from '@mui/icons-material/Close';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
 
 const LogoUploader = ({ logo, setLogo, onWarning }) => {
   const inputRef = useRef(null);
@@ -35,9 +36,10 @@ const LogoUploader = ({ logo, setLogo, onWarning }) => {
         variant="contained"
         component="label"
         color="primary"
+        startIcon={<UploadFileIcon />}
         sx={{ textTransform: "none" }}
       >
-        Upload Logo
+        Select File
         <input
           ref={inputRef}
           type="file"
@@ -57,6 +59,15 @@ const LogoUploader = ({ logo, setLogo, onWarning }) => {
           >
             <CloseIcon fontSize="small" />
           </IconButton>
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={removeLogo}
+            size="small"
+            sx={{ mt: 1 }}
+          >
+            Remove Logo
+          </Button>
         </Box>
       )}
     </Stack>

--- a/src/components/QRCodeDisplay.jsx
+++ b/src/components/QRCodeDisplay.jsx
@@ -3,14 +3,26 @@ import { Box, CircularProgress } from "@mui/material";
 import QRCodeStyling from "qr-code-styling";
 
 const QRCodeDisplay = ({ text, color, bgColor, shape, logo }) => {
+  const containerRef = useRef(null);
   const ref = useRef(null);
   const qrRef = useRef(null);
   const [loading, setLoading] = useState(true);
+  const [size, setSize] = useState({ width: 250, height: 250 });
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const resizeObserver = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      setSize({ width, height });
+    });
+    resizeObserver.observe(containerRef.current);
+    return () => resizeObserver.disconnect();
+  }, []);
 
   useEffect(() => {
     const options = {
-      width: 220,
-      height: 220,
+      width: size.width,
+      height: size.height,
       data: text,
       qrOptions: { errorCorrectionLevel: "H" },
       image: logo || undefined,
@@ -32,23 +44,26 @@ const QRCodeDisplay = ({ text, color, bgColor, shape, logo }) => {
       qrRef.current.update(options);
       setLoading(false);
     }
-  }, [text, color, bgColor, shape, logo]);
+  }, [text, color, bgColor, shape, logo, size]);
 
   return (
     <Box
       id="qr-code"
+      ref={containerRef}
       sx={{
         position: "relative",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        width: 250,
-        height: 250,
+        width: size.width,
+        height: size.height,
         bgcolor: bgColor,
         m: "auto",
         borderRadius: "16px",
         boxShadow: 4,
         border: "1px solid #e0e0e0",
+        resize: "both",
+        overflow: "hidden",
       }}
     >
       <Box


### PR DESCRIPTION
## Summary
- make QR display resizable with ResizeObserver
- hide resize handle when exporting to PNG or PDF
- add material style to file selection and remove logo button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685059f64c3c8325a33e05c61b85ff45