### PR TITLE
Add draggable QR overlay with zoom

### DIFF
--- a/src/components/ImagePlacement.jsx
+++ b/src/components/ImagePlacement.jsx
@@ -1,0 +1,90 @@
+import { useState, useRef } from "react";
+import { Box, Button, Slider, Stack } from "@mui/material";
+import QRCodeDisplay from "./QRCodeDisplay";
+
+const ImagePlacement = ({ image, setImage, qrProps }) => {
+  const [scale, setScale] = useState(1);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+  const containerRef = useRef(null);
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => setImage(reader.result);
+    reader.readAsDataURL(file);
+  };
+
+  const startDrag = (e) => {
+    e.preventDefault();
+    setDragging(true);
+  };
+
+  const endDrag = () => {
+    setDragging(false);
+  };
+
+  const onDrag = (e) => {
+    if (!dragging) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    setPos({
+      x: e.clientX - rect.left - 125,
+      y: e.clientY - rect.top - 125,
+    });
+  };
+
+  return (
+    <Stack spacing={2} alignItems="center">
+      <Button variant="contained" component="label" sx={{ textTransform: "none" }}>
+        Upload Image
+        <input type="file" accept="image/*" hidden onChange={handleFileChange} />
+      </Button>
+      {image && (
+        <>
+          <Box
+            ref={containerRef}
+            sx={{
+              position: "relative",
+              width: "100%",
+              maxWidth: "600px",
+              border: "1px solid #ccc",
+              overflow: "hidden",
+            }}
+            onMouseMove={onDrag}
+            onMouseUp={endDrag}
+            onMouseLeave={endDrag}
+          >
+            <img
+              src={image}
+              alt="Background"
+              style={{
+                width: "100%",
+                display: "block",
+                transform: `scale(${scale})`,
+                transformOrigin: "top left",
+              }}
+            />
+            <Box
+              sx={{ position: "absolute", top: pos.y, left: pos.x, cursor: "move" }}
+              onMouseDown={startDrag}
+            >
+              <QRCodeDisplay {...qrProps} />
+            </Box>
+          </Box>
+          <Box sx={{ width: "100%", maxWidth: 300 }}>
+            <Slider
+              value={scale}
+              min={0.5}
+              max={2}
+              step={0.1}
+              onChange={(_, val) => setScale(val)}
+            />
+          </Box>
+        </>
+      )}
+    </Stack>
+  );
+};
+
+export default ImagePlacement;

--- a/src/components/QRGenerator.jsx
+++ b/src/components/QRGenerator.jsx
@@ -4,6 +4,7 @@ import QRCodeDisplay from "./QRCodeDisplay";
 import DownloadOptions from "./DownloadOptions";
 import LogoUploader from "./LogoUploader";
 import QRContentForm from "./QRContentForm";
+import ImagePlacement from "./ImagePlacement";
 import { generateWhatsappLink } from "../utils/whatsapp";
 import {
   Typography,
@@ -30,6 +31,7 @@ const QRGenerator = () => {
   const [transparent, setTransparent] = useState(false);
   const [warning, setWarning] = useState("");
   const [logo, setLogo] = useState(null);
+  const [bgImage, setBgImage] = useState(null);
 
   const qrValue =
     qrType === "whatsapp"
@@ -103,16 +105,26 @@ const QRGenerator = () => {
           </Card>
 
           <Card elevation={2}>
-            <CardContent>
-              <QRCodeDisplay
-                text={qrValue}
-                color={color}
-                bgColor={bgColor}
-                shape={shape}
-                logo={logo}
-              />
-            </CardContent>
-          </Card>
+          <CardContent>
+            <QRCodeDisplay
+              text={qrValue}
+              color={color}
+              bgColor={bgColor}
+              shape={shape}
+              logo={logo}
+            />
+          </CardContent>
+        </Card>
+
+        <Card elevation={2}>
+          <CardContent>
+            <ImagePlacement
+              image={bgImage}
+              setImage={setBgImage}
+              qrProps={{ text: qrValue, color, bgColor, shape, logo }}
+            />
+          </CardContent>
+        </Card>
 
           <Card elevation={2}>
             <CardContent>


### PR DESCRIPTION
## Summary
- integrate new `ImagePlacement` component
- allow uploading a background image and dragging the QR code
- support zooming the image for better placement

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68516c2d8a608325a4d70072afa7f2e7